### PR TITLE
Add BBS ANSI output mode with CP437 encoding

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -74,6 +74,7 @@ r := img2ansi.NewRenderer(
     img2ansi.WithColorMethod(img2ansi.LABMethod{}),  // LABMethod{}, RedmeanMethod{}, RGBMethod{}
     img2ansi.WithKdSearch(50),                 // KD-tree search depth (0 = use precomputed tables)
     img2ansi.WithCacheThreshold(40.0),         // Error threshold for cache hits
+    img2ansi.WithBBSMode(false),               // BBS output: CP437 encoding, legacy codes (ice=true for 16 BG colors)
 )
 ```
 
@@ -168,6 +169,11 @@ r.BrownDitherForBlocks(resize(img, 80, 40), edges3)   // More hits
 func (r *Renderer) BrownDitherForBlocks(img *imageutil.RGBAImage, edges *imageutil.GrayImage) [][]BlockRune
 func (r *Renderer) RenderToAnsi(blocks [][]BlockRune) string
 func (r *Renderer) CompressANSI(ansi string) string
+func (r *Renderer) CompressBBS(blocks [][]BlockRune) []byte  // BBS-compatible CP437 output
+
+// High-level rendering
+func (r *Renderer) ImageToANSI(imagePath string) (string, error)
+func (r *Renderer) ImageToBBS(imagePath string) ([]byte, error) // BBS-compatible output
 
 // Statistics
 func (r *Renderer) CacheStats() (hits, misses int, hitRate float64)

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ go build github.com/wbrown/ansi2img/cmd/ansify
 ```
 
 ## Usage
-`./img2ansi -input <input> [-output <output>] [-width <width>]
-[-scale <scale>] [-quantization <quantization>] [-maxchars <maxchars>]
-[-color_method <color_method>] [-palette <palette>] [-kdsearch <kdsearch>]
-[-cache_threshold <cache_threshold>]`
+`./ansify -input <input> [-output <output>] [-width <width>]
+[-scale <scale>] [-maxchars <maxchars>]
+[-colormethod <colormethod>] [-palette <palette>] [-kdsearch <kdsearch>]
+[-cache_threshold <cache_threshold>] [-bbs] [-ice]`
 
 **Performance**
 
@@ -124,23 +124,39 @@ this is the primary factor in determining the output ANSI dimensions. The
 default `-scale` is `2`, which approximately halves the height of the output,
 to compensate for the fact that characters are taller than they are wide.
 
+**BBS Output**
+
+The `-bbs` flag produces BBS-compatible `.ANS` files with CP437 encoding, legacy
+ANSI escape codes (`ESC[1;3xm` for bright foreground, `ESC[5;4xm` for bright
+background), and CR+LF line endings. Only the 6 block characters available in
+CP437 are used (space, `▀`, `▄`, `▌`, `▐`, `█`). BBS mode forces the `ansi16`
+palette.
+
+The `-ice` flag enables iCE colors, which repurposes the blink attribute to
+allow 16 background colors instead of 8. The viewer must support iCE colors
+(e.g. SyncTERM, PabloDraw) or bright backgrounds will blink instead.
+
 ```
+  -bbs
+    	Output BBS-compatible .ANS files (CP437 encoding, legacy escape codes, CR+LF)
   -cache_threshold float
-    	Threshold for block cache (default 40)
+    	Max error for approximate cache matches (higher=faster, lower=better quality) (default 200)
   -colormethod string
     	Color distance method: RGB, LAB, or Redmean (default "RGB")
+  -ice
+    	Enable iCE colors for BBS mode: 16 background colors instead of 8.
+    	Requires -bbs. Viewers must support iCE (SyncTERM, PabloDraw)
+    	or bright backgrounds will blink instead
   -input string
     	Path to the input image file (required)
   -kdsearch int
-    	Number of nearest neighbors to search in KD-tree, 0 to disable (default 50)
+    	KD-tree search depth (0=use fast precomputed tables, >0=runtime search)
   -maxchars int
     	Maximum number of characters in the output (default 1048576)
   -output string
     	Path to save the output (if not specified, prints to stdout)
   -palette string
     	Path to the palette file (Embedded: ansi16, ansi256, jetbrains32) (default "ansi16")
-  -quantization int
-    	Quantization factor (default 256)
   -scale float
     	Scale factor for the output image (default 2)
   -width int

--- a/bbs.go
+++ b/bbs.go
@@ -1,0 +1,222 @@
+package img2ansi
+
+import (
+	"fmt"
+)
+
+// unicodeToCP437 maps Unicode block characters to their CP437 byte equivalents.
+var unicodeToCP437 = map[rune]byte{
+	' ': 0x20, // Space
+	'█': 0xDB, // Full block
+	'▄': 0xDC, // Lower half block
+	'▌': 0xDD, // Left half block
+	'▐': 0xDE, // Right half block
+	'▀': 0xDF, // Upper half block
+}
+
+// bbsFgCode converts a modern ANSI foreground color code to BBS format.
+// Standard colors (30-37) get "0;" prefix to clear sticky bold.
+// Bright colors (90-97) become "1;3x" (bold + standard color).
+func bbsFgCode(code string) string {
+	switch code {
+	case "30":
+		return "0;30"
+	case "31":
+		return "0;31"
+	case "32":
+		return "0;32"
+	case "33":
+		return "0;33"
+	case "34":
+		return "0;34"
+	case "35":
+		return "0;35"
+	case "36":
+		return "0;36"
+	case "37":
+		return "0;37"
+	case "90":
+		return "1;30"
+	case "91":
+		return "1;31"
+	case "92":
+		return "1;32"
+	case "93":
+		return "1;33"
+	case "94":
+		return "1;34"
+	case "95":
+		return "1;35"
+	case "96":
+		return "1;36"
+	case "97":
+		return "1;37"
+	default:
+		return code
+	}
+}
+
+// bbsBgCode converts a modern ANSI background color code to BBS format.
+// Standard colors (40-47) pass through as-is.
+// Bright colors (100-107) become "5;4x" (blink + standard bg) when iCE colors
+// are enabled, otherwise fall back to the standard color (40-47).
+func bbsBgCode(code string, ice bool) string {
+	switch code {
+	case "40", "41", "42", "43", "44", "45", "46", "47":
+		return code
+	case "100":
+		if ice {
+			return "5;40"
+		}
+		return "40"
+	case "101":
+		if ice {
+			return "5;41"
+		}
+		return "41"
+	case "102":
+		if ice {
+			return "5;42"
+		}
+		return "42"
+	case "103":
+		if ice {
+			return "5;43"
+		}
+		return "43"
+	case "104":
+		if ice {
+			return "5;44"
+		}
+		return "44"
+	case "105":
+		if ice {
+			return "5;45"
+		}
+		return "45"
+	case "106":
+		if ice {
+			return "5;46"
+		}
+		return "46"
+	case "107":
+		if ice {
+			return "5;47"
+		}
+		return "47"
+	default:
+		return code
+	}
+}
+
+// CompressBBS renders block data to BBS-compatible ANSI art with CP437 encoding.
+// Output uses legacy escape codes (ESC[1;3xm for bright FG, ESC[5;4xm for bright BG),
+// CR+LF line endings, and CP437 bytes for block characters.
+// Returns []byte since CP437 is not valid UTF-8.
+func (r *Renderer) CompressBBS(blocks [][]BlockRune) []byte {
+	var buf []byte
+
+	var currentFg, currentBg string
+	var pendingChars []byte
+
+	flush := func() {
+		if len(pendingChars) == 0 {
+			return
+		}
+		buf = append(buf, pendingChars...)
+		pendingChars = pendingChars[:0]
+	}
+
+	writeColor := func(fg, bg string) {
+		// Build full attribute set to avoid sticky bold/blink issues
+		buf = append(buf, fmt.Sprintf("\x1b[0;%s;%sm", fg, bg)...)
+		currentFg = fg
+		currentBg = bg
+	}
+
+	for _, row := range blocks {
+		currentFg = ""
+		currentBg = ""
+		pendingChars = pendingChars[:0]
+
+		for _, block := range row {
+			fgCode, _ := r.fgAnsi.Get(block.FG.toUint32())
+			bgCode, _ := r.bgAnsi.Get(block.BG.toUint32())
+
+			fg := bbsFgCode(fgCode.(string))
+			bg := bbsBgCode(bgCode.(string), r.ICEColors)
+
+			cp437Byte, ok := unicodeToCP437[block.Rune]
+			if !ok {
+				// Fallback: use space for any unmapped character
+				cp437Byte = 0x20
+			}
+
+			// Optimize: full block only needs bg color (render as space with bg)
+			// and space only needs... well, space with bg color
+			if block.Rune == '█' {
+				// Full block: render as space with fg as bg
+				fgAsBg := bbsBgCode(bgCodeFromFg(fgCode.(string)), r.ICEColors)
+				if currentFg != "0;30" || currentBg != fgAsBg {
+					flush()
+					writeColor("0;30", fgAsBg)
+				}
+				pendingChars = append(pendingChars, 0x20)
+				continue
+			}
+
+			if fg != currentFg || bg != currentBg {
+				flush()
+				writeColor(fg, bg)
+			}
+			pendingChars = append(pendingChars, cp437Byte)
+		}
+
+		flush()
+		// Reset and CR+LF
+		buf = append(buf, "\x1b[0m\r\n"...)
+	}
+
+	return buf
+}
+
+// bgCodeFromFg converts a foreground ANSI code to the equivalent background code.
+// e.g., "31" -> "41", "91" -> "101"
+func bgCodeFromFg(fgCode string) string {
+	switch fgCode {
+	case "30":
+		return "40"
+	case "31":
+		return "41"
+	case "32":
+		return "42"
+	case "33":
+		return "43"
+	case "34":
+		return "44"
+	case "35":
+		return "45"
+	case "36":
+		return "46"
+	case "37":
+		return "47"
+	case "90":
+		return "100"
+	case "91":
+		return "101"
+	case "92":
+		return "102"
+	case "93":
+		return "103"
+	case "94":
+		return "104"
+	case "95":
+		return "105"
+	case "96":
+		return "106"
+	case "97":
+		return "107"
+	default:
+		return "40"
+	}
+}

--- a/bbs_test.go
+++ b/bbs_test.go
@@ -1,0 +1,247 @@
+package img2ansi
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBbsFgCode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Standard colors get 0; prefix to clear sticky bold
+		{"30", "0;30"},
+		{"31", "0;31"},
+		{"32", "0;32"},
+		{"33", "0;33"},
+		{"34", "0;34"},
+		{"35", "0;35"},
+		{"36", "0;36"},
+		{"37", "0;37"},
+		// Bright colors become 1;3x (bold + standard)
+		{"90", "1;30"},
+		{"91", "1;31"},
+		{"92", "1;32"},
+		{"93", "1;33"},
+		{"94", "1;34"},
+		{"95", "1;35"},
+		{"96", "1;36"},
+		{"97", "1;37"},
+	}
+
+	for _, tt := range tests {
+		result := bbsFgCode(tt.input)
+		if result != tt.expected {
+			t.Errorf("bbsFgCode(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestBbsBgCodeWithICE(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Standard BG colors pass through
+		{"40", "40"},
+		{"41", "41"},
+		{"42", "42"},
+		{"43", "43"},
+		{"44", "44"},
+		{"45", "45"},
+		{"46", "46"},
+		{"47", "47"},
+		// Bright BG colors become 5;4x with iCE
+		{"100", "5;40"},
+		{"101", "5;41"},
+		{"102", "5;42"},
+		{"103", "5;43"},
+		{"104", "5;44"},
+		{"105", "5;45"},
+		{"106", "5;46"},
+		{"107", "5;47"},
+	}
+
+	for _, tt := range tests {
+		result := bbsBgCode(tt.input, true)
+		if result != tt.expected {
+			t.Errorf("bbsBgCode(%q, true) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestBbsBgCodeWithoutICE(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Standard BG colors pass through
+		{"40", "40"},
+		{"47", "47"},
+		// Bright BG colors fall back to standard without iCE
+		{"100", "40"},
+		{"101", "41"},
+		{"102", "42"},
+		{"103", "43"},
+		{"104", "44"},
+		{"105", "45"},
+		{"106", "46"},
+		{"107", "47"},
+	}
+
+	for _, tt := range tests {
+		result := bbsBgCode(tt.input, false)
+		if result != tt.expected {
+			t.Errorf("bbsBgCode(%q, false) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestUnicodeToCP437Mapping(t *testing.T) {
+	tests := []struct {
+		r        rune
+		expected byte
+	}{
+		{' ', 0x20},
+		{'█', 0xDB},
+		{'▄', 0xDC},
+		{'▌', 0xDD},
+		{'▐', 0xDE},
+		{'▀', 0xDF},
+	}
+
+	for _, tt := range tests {
+		b, ok := unicodeToCP437[tt.r]
+		if !ok {
+			t.Errorf("unicodeToCP437[%q] not found", tt.r)
+			continue
+		}
+		if b != tt.expected {
+			t.Errorf("unicodeToCP437[%q] = 0x%02X, want 0x%02X", tt.r, b, tt.expected)
+		}
+	}
+}
+
+func TestCompressBBSProducesValidOutput(t *testing.T) {
+	// Create a simple renderer with ansi16 palette for testing
+	r := NewRenderer(
+		WithBBSMode(true),
+		WithPalette("ansi16"),
+	)
+
+	// Use actual ANSI 16 palette colors (from ansi16.json)
+	black := RGB{0x00, 0x00, 0x00}   // code 30/40
+	red := RGB{0xAA, 0x00, 0x00}     // code 31/41
+	green := RGB{0x00, 0xAA, 0x00}   // code 32/42
+	blue := RGB{0x00, 0x00, 0xAA}    // code 34/44
+	yellow := RGB{0xAA, 0x55, 0x00}  // code 33/43
+	brightRed := RGB{0xFF, 0x55, 0x55} // code 91/101
+
+	// Create a small test block grid (2x2 blocks)
+	blocks := [][]BlockRune{
+		{
+			{Rune: '▀', FG: red, BG: black},
+			{Rune: '█', FG: green, BG: black},
+		},
+		{
+			{Rune: ' ', FG: black, BG: blue},
+			{Rune: '▄', FG: yellow, BG: brightRed},
+		},
+	}
+
+	output := r.CompressBBS(blocks)
+
+	// Verify output is non-empty
+	if len(output) == 0 {
+		t.Fatal("CompressBBS produced empty output")
+	}
+
+	// Verify CR+LF line endings
+	if !bytes.Contains(output, []byte("\r\n")) {
+		t.Error("Output should contain CR+LF line endings")
+	}
+
+	// Verify block characters are single CP437 bytes, not multi-byte UTF-8.
+	// Unicode block chars like '▀' are 3 bytes in UTF-8 (e.g., 0xE2 0x96 0x80).
+	// In CP437 they're single bytes (0xDB-0xDF). Check that no 3-byte UTF-8
+	// sequences for block characters appear in the output.
+	unicodeBlockPrefix := []byte{0xE2, 0x96} // Common prefix for Unicode block elements
+	if bytes.Contains(output, unicodeBlockPrefix) {
+		t.Error("Output contains multi-byte UTF-8 block characters - should be CP437 single bytes")
+	}
+
+	// Verify escape codes use legacy BBS format
+	// Should contain "0;" or "1;" prefixes, not bare "9x" codes
+	outputStr := string(output)
+	if bytes.Contains(output, []byte("\x1b[91")) {
+		t.Error("Output should not contain modern bright FG codes like ESC[91")
+	}
+	_ = outputStr
+
+	// Verify reset at end of each line
+	lines := bytes.Split(output, []byte("\r\n"))
+	for i, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		if !bytes.HasSuffix(line, []byte("\x1b[0m")) {
+			t.Errorf("Line %d should end with ESC[0m reset", i)
+		}
+	}
+}
+
+func TestBBSModeBlockSet(t *testing.T) {
+	r := NewRenderer(
+		WithBBSMode(true),
+		WithPalette("ansi16"),
+	)
+
+	blocks := r.getBlocks()
+
+	// Should have exactly 6 blocks
+	if len(blocks) != 6 {
+		t.Errorf("BBS mode should have 6 blocks, got %d", len(blocks))
+	}
+
+	// All blocks should be in CP437
+	for _, b := range blocks {
+		if _, ok := unicodeToCP437[b.Rune]; !ok {
+			t.Errorf("BBS block %q (U+%04X) not in CP437 map", b.Rune, b.Rune)
+		}
+	}
+}
+
+func TestDefaultBlockSetUnchanged(t *testing.T) {
+	r := NewRenderer(
+		WithPalette("ansi16"),
+	)
+
+	blocks := r.getBlocks()
+
+	// Default should still have 16 blocks
+	if len(blocks) != 16 {
+		t.Errorf("Default mode should have 16 blocks, got %d", len(blocks))
+	}
+}
+
+func TestBgCodeFromFg(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"30", "40"},
+		{"31", "41"},
+		{"37", "47"},
+		{"90", "100"},
+		{"91", "101"},
+		{"97", "107"},
+	}
+
+	for _, tt := range tests {
+		result := bgCodeFromFg(tt.input)
+		if result != tt.expected {
+			t.Errorf("bgCodeFromFg(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}

--- a/cmd/ansify/ansify.go
+++ b/cmd/ansify/ansify.go
@@ -64,6 +64,12 @@ func main() {
 		"Max error for approximate cache matches (higher=faster, lower=better quality)")
 	colorMethod := flag.String("colormethod",
 		"RGB", "Color distance method: RGB, LAB, or Redmean")
+	bbsMode := flag.Bool("bbs", false,
+		"Output BBS-compatible .ANS files (CP437 encoding, legacy escape codes, CR+LF)")
+	iceColors := flag.Bool("ice", false,
+		"Enable iCE colors for BBS mode: 16 background colors instead of 8.\n"+
+			"    \tRequires -bbs. Viewers must support iCE (SyncTERM, PabloDraw)\n"+
+			"    \tor bright backgrounds will blink instead")
 	//printTable := flag.Bool("table", false,
 	//	"Print ANSI color table")
 	// Parse flags
@@ -96,17 +102,29 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create Renderer
-	startInit := time.Now()
-	r := img2ansi.NewRenderer(
+	// Force ansi16 palette in BBS mode
+	if *bbsMode {
+		*paletteFile = "ansi16"
+	}
+
+	// Build renderer options
+	opts := []img2ansi.RendererOption{
 		img2ansi.WithTargetWidth(*targetWidth),
 		img2ansi.WithScaleFactor(*scaleFactor),
 		img2ansi.WithMaxChars(*maxChars),
 		img2ansi.WithKdSearch(*kdSearchDepth),
 		img2ansi.WithCacheThreshold(*threshold),
 		img2ansi.WithColorMethod(method),
-		img2ansi.WithPalette(*paletteFile),
-	)
+	}
+	if *bbsMode {
+		opts = append(opts, img2ansi.WithBBSMode(*iceColors))
+	}
+	// Palette must be loaded last (after color method and BBS mode are set)
+	opts = append(opts, img2ansi.WithPalette(*paletteFile))
+
+	// Create Renderer
+	startInit := time.Now()
+	r := img2ansi.NewRenderer(opts...)
 	endInit := time.Now()
 
 	// Error out if precomputed tables aren't available (would be too slow)
@@ -126,35 +144,67 @@ func main() {
 		return
 	}
 
-	// Generate ANSI art
-	ansiArt, err := r.ImageToANSI(*inputFile)
-	if err != nil {
-		fmt.Printf("Error converting image: %v\n", err)
-		os.Exit(1)
-	}
-	compressedArt := r.CompressANSI(ansiArt)
-	endComputation := time.Now()
-
-	// Output result
-	if *outputFile != "" {
-		err := os.WriteFile(*outputFile, []byte(compressedArt), 0644)
+	if *bbsMode {
+		// Generate BBS ANSI art
+		bbsArt, err := r.ImageToBBS(*inputFile)
 		if err != nil {
-			fmt.Printf("Error writing to file: %v\n", err)
-			return
+			fmt.Printf("Error converting image: %v\n", err)
+			os.Exit(1)
 		}
-		fmt.Printf("Output written to %s\n", *outputFile)
-	} else {
-		fmt.Print(compressedArt)
-	}
+		endComputation := time.Now()
 
-	hits, misses, hitRate := r.CacheStats()
-	uniqueKeys, sharedKeys, totalBlocks, avgError := r.CacheKeyStats()
-	fmt.Printf("Computation time: %v\n", endComputation.Sub(endInit))
-	fmt.Printf("BestBlock calculation time: %v\n", r.GetBestBlockTime())
-	fmt.Printf("Total string length: %d\n", len(ansiArt))
-	fmt.Printf("Compressed string length: %d\n", len(compressedArt))
-	fmt.Printf("Block Cache: %d hits, %d misses (%.1f%% hit rate)\n",
-		hits, misses, hitRate*100)
-	fmt.Printf("Cache Keys: %d unique, %d shared (%d blocks, avg error %.1f)\n",
-		uniqueKeys, sharedKeys, totalBlocks, avgError)
+		// Output result
+		if *outputFile != "" {
+			err := os.WriteFile(*outputFile, bbsArt, 0644)
+			if err != nil {
+				fmt.Printf("Error writing to file: %v\n", err)
+				return
+			}
+			fmt.Printf("Output written to %s\n", *outputFile)
+		} else {
+			os.Stdout.Write(bbsArt)
+		}
+
+		hits, misses, hitRate := r.CacheStats()
+		uniqueKeys, sharedKeys, totalBlocks, avgError := r.CacheKeyStats()
+		fmt.Fprintf(os.Stderr, "Computation time: %v\n", endComputation.Sub(endInit))
+		fmt.Fprintf(os.Stderr, "BestBlock calculation time: %v\n", r.GetBestBlockTime())
+		fmt.Fprintf(os.Stderr, "BBS output size: %d bytes\n", len(bbsArt))
+		fmt.Fprintf(os.Stderr, "Block Cache: %d hits, %d misses (%.1f%% hit rate)\n",
+			hits, misses, hitRate*100)
+		fmt.Fprintf(os.Stderr, "Cache Keys: %d unique, %d shared (%d blocks, avg error %.1f)\n",
+			uniqueKeys, sharedKeys, totalBlocks, avgError)
+	} else {
+		// Generate ANSI art
+		ansiArt, err := r.ImageToANSI(*inputFile)
+		if err != nil {
+			fmt.Printf("Error converting image: %v\n", err)
+			os.Exit(1)
+		}
+		compressedArt := r.CompressANSI(ansiArt)
+		endComputation := time.Now()
+
+		// Output result
+		if *outputFile != "" {
+			err := os.WriteFile(*outputFile, []byte(compressedArt), 0644)
+			if err != nil {
+				fmt.Printf("Error writing to file: %v\n", err)
+				return
+			}
+			fmt.Printf("Output written to %s\n", *outputFile)
+		} else {
+			fmt.Print(compressedArt)
+		}
+
+		hits, misses, hitRate := r.CacheStats()
+		uniqueKeys, sharedKeys, totalBlocks, avgError := r.CacheKeyStats()
+		fmt.Printf("Computation time: %v\n", endComputation.Sub(endInit))
+		fmt.Printf("BestBlock calculation time: %v\n", r.GetBestBlockTime())
+		fmt.Printf("Total string length: %d\n", len(ansiArt))
+		fmt.Printf("Compressed string length: %d\n", len(compressedArt))
+		fmt.Printf("Block Cache: %d hits, %d misses (%.1f%% hit rate)\n",
+			hits, misses, hitRate*100)
+		fmt.Printf("Cache Keys: %d unique, %d shared (%d blocks, avg error %.1f)\n",
+			uniqueKeys, sharedKeys, totalBlocks, avgError)
+	}
 }

--- a/img2ansi.go
+++ b/img2ansi.go
@@ -40,6 +40,17 @@ type blockDef struct {
 	Quad Quadrants
 }
 
+// BBSBlocks defines the 6 block characters available in CP437 encoding.
+// These are the only Unicode block characters that have CP437 equivalents.
+var BBSBlocks = []blockDef{
+	{' ', Quadrants{false, false, false, false}}, // Space (0x20)
+	{'▀', Quadrants{true, true, false, false}},   // Upper half block (0xDF)
+	{'▄', Quadrants{false, false, true, true}},   // Lower half block (0xDC)
+	{'▌', Quadrants{true, false, true, false}},   // Left half block (0xDD)
+	{'▐', Quadrants{false, true, false, true}},   // Right half block (0xDE)
+	{'█', Quadrants{true, true, true, true}},     // Full block (0xDB)
+}
+
 // BlockRune represents a 2x2 block of runes with foreground and
 // background colors mapped in the ANSI color space. The struct contains
 // a rune representing the block character, and two RGB colors representing
@@ -184,7 +195,7 @@ func (r *Renderer) FindBestBlockRepresentation(block [4]RGB, isEdge bool) (rune,
 		var bestFG, bestBG RGB
 		minError := math.MaxFloat64
 
-		for _, b := range Blocks {
+		for _, b := range r.getBlocks() {
 			r.fgAnsi.Iterate(func(fg, _ interface{}) {
 				fgRgb := rgbFromUint32(fg.(uint32))
 				r.bgAnsi.Iterate(func(bg, _ interface{}) {
@@ -223,7 +234,7 @@ func (r *Renderer) FindBestBlockRepresentation(block [4]RGB, isEdge bool) (rune,
 	var bestFG, bestBG RGB
 	minError := math.MaxFloat64
 
-	for _, b := range Blocks {
+	for _, b := range r.getBlocks() {
 		for _, fgWithDist := range foregroundColors {
 			for _, bgWithDist := range backgroundColors {
 				fg, bg := fgWithDist.color, bgWithDist.color
@@ -376,6 +387,51 @@ func (r *Renderer) ImageToANSI(imagePath string) (string, error) {
 		height = int(float64(width) / aspectRatio / 2)
 		if width < 10 {
 			return "", fmt.Errorf("image too large to fit within character limit")
+		}
+	}
+}
+
+// ImageToBBS converts an image to BBS-compatible ANSI art with CP437 encoding.
+// Returns raw bytes (not a string) since CP437 is not valid UTF-8.
+func (r *Renderer) ImageToBBS(imagePath string) ([]byte, error) {
+	img, err := imageutil.LoadImage(imagePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read image from %s: %v", imagePath, err)
+	}
+
+	aspectRatio := float64(img.Width()) / float64(img.Height())
+	width := r.TargetWidth
+	height := int(float64(width) / aspectRatio / r.ScaleFactor)
+
+	for {
+		resized, edges := imageutil.PrepareForANSI(img, width, height)
+		ditheredImg := r.BrownDitherForBlocks(resized, edges)
+
+		// Write debug files
+		if err := imageutil.SavePNG(resized.RGBA, "resized.png"); err != nil {
+			fmt.Println(err)
+		}
+		if err := saveBlocksToPNG(ditheredImg,
+			"dithered.png",
+			len(ditheredImg[0])*8,
+			int(float64(len(ditheredImg)*8)*r.ScaleFactor),
+			r.ScaleFactor,
+		); err != nil {
+			fmt.Println(err)
+		}
+		if err := imageutil.SaveGrayImage(edges, "edges.png"); err != nil {
+			fmt.Println(err)
+		}
+
+		bbsOutput := r.CompressBBS(ditheredImg)
+		if len(bbsOutput) <= r.MaxChars {
+			return bbsOutput, nil
+		}
+
+		width -= 2
+		height = int(float64(width) / aspectRatio / 2)
+		if width < 10 {
+			return nil, fmt.Errorf("image too large to fit within character limit")
 		}
 	}
 }

--- a/renderer.go
+++ b/renderer.go
@@ -25,6 +25,10 @@ type Renderer struct {
 	CacheThreshold float64
 	ColorMethod    ColorDistanceMethod
 
+	// Block set override (nil = use default Blocks)
+	blocks    []blockDef
+	ICEColors bool
+
 	// Palette state (private)
 	palettePath   string
 	paletteLoaded bool
@@ -136,6 +140,25 @@ func WithTargetWidth(width int) RendererOption {
 	return func(r *Renderer) {
 		r.TargetWidth = width
 	}
+}
+
+// WithBBSMode configures the renderer for BBS-compatible output.
+// It restricts the block set to 6 CP437-compatible characters and
+// sets ICE colors mode (16 background colors via blink attribute).
+func WithBBSMode(iceColors bool) RendererOption {
+	return func(r *Renderer) {
+		r.blocks = BBSBlocks
+		r.ICEColors = iceColors
+	}
+}
+
+// getBlocks returns the block set to use for rendering.
+// Returns the custom block set if configured, otherwise the default 16 Unicode blocks.
+func (r *Renderer) getBlocks() []blockDef {
+	if r.blocks != nil {
+		return r.blocks
+	}
+	return Blocks
 }
 
 // LoadPalette loads a color palette from the given path.


### PR DESCRIPTION
## Summary
- Add `-bbs` flag that produces BBS-compatible `.ANS` files with CP437 encoding, legacy escape codes, CR+LF line endings, and the 6 block characters available in CP437
- Add `-ice` flag to enable iCE colors (16 background colors via blink attribute) for BBS mode
- Make the block character set configurable on the Renderer (`WithBBSMode()`, `getBlocks()`)

## Changes
- **`renderer.go`** — `blocks`/`ICEColors` fields, `getBlocks()` method, `WithBBSMode()` option
- **`img2ansi.go`** — `BBSBlocks` (6 CP437 blocks), configurable block search, `ImageToBBS()` method
- **`bbs.go`** (new) — CP437 byte mapping, legacy ANSI code translation, `CompressBBS()` renderer method
- **`bbs_test.go`** (new) — Unit tests for FG/BG code translation, CP437 mapping, output validation, block set verification
- **`cmd/ansify/ansify.go`** — `-bbs` and `-ice` CLI flags, BBS output path
- **`README.md`** / **`MIGRATION.md`** — Documentation for BBS mode

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./cmd/ansify` succeeds
- [ ] Test BBS output with `./ansify -input test.png -bbs -output test.ans -width 80`
- [ ] Verify output in a BBS ANSI viewer (SyncTERM, PabloDraw, Moebius)
- [ ] Verify CR+LF line endings and CP437 block bytes in output
- [ ] Test `-ice` flag produces `5;4x` escape codes for bright backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)